### PR TITLE
docs: fix simple typo, encryping -> encrypting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import bugbuzz; bugbuzz.set_trace()
 
 # Security concerns
 
-As bugbuzz providing debugging in a software-as-service manner, all source code and local variables needed will be uploaded to the server. When a debugging session created, a random secret access key will be generated, and used for encryping all source code and local variables. The access key will be passed to dashboard as a part of hash tag like this
+As bugbuzz providing debugging in a software-as-service manner, all source code and local variables needed will be uploaded to the server. When a debugging session created, a random secret access key will be generated, and used for encrypting all source code and local variables. The access key will be passed to dashboard as a part of hash tag like this
 
 ```
 http://dashboard.bugbuzz.io/#/sessions/SECsLArhHBVHF5mrtvXHVp3T?access_key=<ACCESS KEY>


### PR DESCRIPTION
There is a small typo in README.md.

Should read `encrypting` rather than `encryping`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md